### PR TITLE
- Converted backtick multi-line strings back into conventional string…

### DIFF
--- a/prototype/css/style.css
+++ b/prototype/css/style.css
@@ -402,10 +402,10 @@ body
 {
   font-style: italic;
 }
-#gcs-about .row:last-of-type
+#gcs-about .row:first-of-type
 {
   position: relative;
-  margin-top: 30vh;
+  margin-top: 14vh;
 }
 #gcs-about p
 {

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -469,7 +469,7 @@
     <div id="legal">
       <div class="container">
         <div class="row">
-          <p class="text-center copyright">&copy Copyright 2014 GameCloud Studios, Inc. All Rights Reserved.</p>
+          <p class="text-center copyright">&copy; Copyright 2014 GameCloud Studios, Inc. All Rights Reserved.</p>
         </div>
       </div>
     </div>

--- a/prototype/script/carousel.js
+++ b/prototype/script/carousel.js
@@ -111,23 +111,11 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
   }
 
   var left_translate = $(
-    `<style>
-      .left-translate 
-      { 
-        transform: translateX(${num_slide / num_visible * 100}%);
-        transition-duration: 1000ms;
-      }
-     </style>`
+    "<style>.left-translate{transform: translateX(" + (num_slide / num_visible * 100) + "%); transition-duration: 1000ms;}</style>"
   );
 
   var right_translate = $(
-    `<style>
-      .right-translate 
-      { 
-        transform: translateX(-${num_slide / num_visible * 100}%);
-        transition-duration: 1000ms;
-      }
-     </style>`
+    "<style>.right-translate{transform: translateX(-" + (num_slide / num_visible * 100) + "%);transition-duration: 1000ms;}</style>"
   );
   
   // {
@@ -150,9 +138,9 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
     var carousel_left_div = $('<div>');
     carousel_left_div.addClass('carousel-left-queue');
     carousel_left_div.css(carousel_left_css);
-    for (let i = 0; i < num_slide; i++)
+    for (var i = 0; i < num_slide; i++)
     {
-      let carousel_reserve_img_container = $('<div>');
+      var carousel_reserve_img_container = $('<div>');
       carousel_reserve_img_container.addClass('carousel-img');
       carousel_reserve_img_container.css(carousel_reserve_img_container_css);
       carousel_reserve_img_container.append($('<img>').css(carousel_unit_element_css));
@@ -162,9 +150,9 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
     var carousel_middle_div = $('<div>'); 
     carousel_middle_div.addClass('carousel-visible');
     carousel_middle_div.css(carousel_middle_css);
-    for (let i = 0; i < num_visible; i++)
+    for (var i = 0; i < num_visible; i++)
     {
-      let carousel_middle_img_container = $('<div>');
+      var carousel_middle_img_container = $('<div>');
       carousel_middle_img_container.addClass('carousel-img');
       carousel_middle_img_container.css(carousel_middle_img_container_css);
       carousel_middle_img_container.append($('<img>').css(carousel_unit_element_css));
@@ -174,9 +162,9 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
     var carousel_right_div = $('<div>');
     carousel_right_div.addClass('carousel-right-queue');
     carousel_right_div.css(carousel_right_css);
-    for (let i = 0; i < num_slide; i++)
+    for (var i = 0; i < num_slide; i++)
     {
-      let carousel_reserve_img_container = $('<div>');
+      var carousel_reserve_img_container = $('<div>');
       carousel_reserve_img_container.addClass('carousel-img');
       carousel_reserve_img_container.css(carousel_reserve_img_container_css);
       carousel_reserve_img_container.append($('<img>').css(carousel_unit_element_css));
@@ -198,9 +186,9 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
     setDomArr(_first_visible);
 
     // query for all image elements in the carousel
-    let dom_imgs = $('.custom-carousel').find('img');
-    let length = dom_imgs.length;
-    for (let i = 0; i < length; i++)
+    var dom_imgs = $('.custom-carousel').find('img');
+    var length = dom_imgs.length;
+    for (var i = 0; i < length; i++)
     {
       $(dom_imgs[i]).attr('src', src_arr[dom_arr[i]]);
     }
@@ -211,7 +199,7 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
     if (dom_arr.length === 0)   
     {
       dom_arr_length = num_slide * 2 + num_visible;
-      for (let i = 0; i < dom_arr_length; i++)
+      for (var i = 0; i < dom_arr_length; i++)
       {
         dom_arr.push(-1);
       }
@@ -223,8 +211,8 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
 
   var setLeftQueue = function(_first_visible)
   {
-    let curr_src_index = _first_visible;
-    for (let i = num_slide - 1; i >= 0; i--)
+    var curr_src_index = _first_visible;
+    for (var i = num_slide - 1; i >= 0; i--)
     {
       curr_src_index = decrementArrayIndex(src_arr, curr_src_index);
       dom_arr[i] = curr_src_index; //src_arr[curr_src_index];
@@ -233,8 +221,8 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
 
   var setVisibleSection = function(_first_visible)
   {
-    let curr_src_index = _first_visible;
-    for (let i = num_slide; i < num_slide + num_visible; i++)
+    var curr_src_index = _first_visible;
+    for (var i = num_slide; i < num_slide + num_visible; i++)
     {
       dom_arr[i] = curr_src_index;
       curr_src_index = incrementArrayIndex(src_arr, curr_src_index);
@@ -243,8 +231,8 @@ function Carousel(_host, _src_arr, _num_visible, _num_slide)
 
   var setRightQueue = function(_last_visible)
   {
-    let curr_src_index = _last_visible;
-    for (let i = num_slide + num_visible; i < dom_arr.length; i++)
+    var curr_src_index = _last_visible;
+    for (var i = num_slide + num_visible; i < dom_arr.length; i++)
     {      
       curr_src_index = incrementArrayIndex(src_arr, curr_src_index);
       dom_arr[i] = curr_src_index; //src_arr[curr_src_index];      

--- a/prototype/script/main.js
+++ b/prototype/script/main.js
@@ -5,7 +5,7 @@ function debugPrint(str)
 {
   if (DEBUG)
   {
-    let msg = `${debug_line++}: ${str}`;
+    var msg = debug_line++ + ':' + str;
     $('#debug-info').append($('<p>').append(msg));
     console.log(msg);
 

--- a/prototype/script/scroll.js
+++ b/prototype/script/scroll.js
@@ -1,8 +1,9 @@
 //document.addEventListener("DOMContentLoaded", function(event)
-$(window).load(function()
+window.addEventListener('load', function()
 {
-  measureElements($(this));
-  checkScroll($(this));
+  console.log('Window loaded!');
+  measureElements(this);
+  checkScroll(this);
 });
 
 var bg_arr = [
@@ -39,34 +40,34 @@ var measureElements = function(the_window)
 
   // Center the BG images
   // if (!bgs_initialized)
-  let bgs = $('#gcs-backgrounds>.img-container').children('img');
+  var bgs = $('#gcs-backgrounds>.img-container').children('img');
   // debugPrint(windowWidth);
   // debugPrint(windowHeight);
-  let length = bgs.length;
-  for (let i = 0; i < length; i++)
+  var length = bgs.length;
+  for (var i = 0; i < length; i++)
   {
     // if (!bgs_initialized)
-    let img_w = bgs[i].clientWidth;
-    let img_h = bgs[i].clientHeight;
-    // let img_ar = img_w / img_h;
-    let nat_ar = bgs[i].naturalWidth / bgs[i].naturalHeight;
-    let win_ar = windowWidth / windowHeight;
+    var img_w = bgs[i].clientWidth;
+    var img_h = bgs[i].clientHeight;
+    // var img_ar = img_w / img_h;
+    var nat_ar = bgs[i].naturalWidth / bgs[i].naturalHeight;
+    var win_ar = windowWidth / windowHeight;
     
 
     // measured_bgs_natural_wh = true;
     // debugPrint((windowWidth - img_w) / 2);
     // if (i == 0)
       // debugPrint(`IMAGE[${i}]: img_w = ${img_w}, img_h = ${img_h}, nat_w = ${bgs[i].naturalWidth}, nat_h = ${bgs[i].naturalHeight}`);
-    // let img_css = {}
+    // var img_css = {}
     // Measuring the background image stylings
     // 1) window's aspect ratio (AR) < image's natural AR -- image height is 100% and confined to viewport, image width is calculated using image height and natural AR and is centered.
     // 2) window's AR >= image's natural AR -- image width is 100% and confined to the viewport. image height is calculated using image width and natural AR and is centered.
     $(bgs[i]).css(
       {
-        'width': `${win_ar >= nat_ar ? 100 : windowHeight * nat_ar / windowWidth * 100}%`,
-        'margin-left': `${win_ar >= nat_ar ? 0 : (windowWidth - img_w) / 2}px`,
-        'height': `${win_ar < nat_ar ? 100 : windowWidth / nat_ar / windowHeight * 100}%`,
-        'margin-top': `0`//${win_ar < nat_ar ? 0 : (windowHeight - img_h) / 2}px`
+        'width': (win_ar >= nat_ar ? 100 : windowHeight * nat_ar / windowWidth * 100) + '%',
+        'margin-left': (win_ar >= nat_ar ? 0 : (windowWidth - img_w) / 2) + 'px',
+        'height': (win_ar < nat_ar ? 100 : windowWidth / nat_ar / windowHeight * 100) + '%',
+        'margin-top': '0'//${win_ar < nat_ar ? 0 : (windowHeight - img_h) / 2}px`
       }
     );
   }
@@ -78,25 +79,27 @@ var measureElements = function(the_window)
   team_pos = $('#gcs-team').offset().top;
 
   project_divs = $('#gcs-portfolio>.container-fluid>.row>div');
-  for (let i = 0; i < project_divs.length; i++)
+  for (var i = 0; i < project_divs.length; i++)
   {
     project_divs[i].dims = {
       pos: $(project_divs[i]).offset().top,
       height:  $(project_divs[i]).height(),
     };
     project_divs[i].visible = false;
-    debugPrint(`project_div[${i}] pos + height = ${(project_divs[i].dims.pos + project_divs[i].dims.height)} and visible = ${project_divs[i].visible}`);
+    // debugPrint(`project_div[${i}] pos + height = ${(project_divs[i].dims.pos + project_divs[i].dims.height)} and visible = ${project_divs[i].visible}`);
+    debugPrint('project_div[' + i + '] pos + height = ' + ((project_divs[i].dims.pos + project_divs[i].dims.height)) + ' and visible = ' + (project_divs[i].visible));
   }
 
   team_divs = $('#gcs-team>.container>.row>div');
-  for (let i = 0; i < team_divs.length; i++)
+  for (var i = 0; i < team_divs.length; i++)
   {
     team_divs[i].dims = {
       pos: $(team_divs[i]).offset().top,
       height:  $(team_divs[i]).height(),
     };
     team_divs[i].visible = false;
-    debugPrint(`team_divs[${i}] pos + height = ${(team_divs[i].dims.pos + team_divs[i].dims.height)}`);
+    // debugPrint(`team_divs[${i}] pos + height = ${(team_divs[i].dims.pos + team_divs[i].dims.height)}`);
+    debugPrint('team_divs[' + i + '] pos + height = ' + ((team_divs[i].dims.pos + team_divs[i].dims.height)) + ' and visible = ' + (team_divs[i].visible));
   }
 
   // debugPrint("windowHeight" + windowHeight);
@@ -115,12 +118,12 @@ $(window).resize(function()
 
 $('#gcs-navbar a').on('click', function()
 {
-  let windowScrollTop = $(window).scrollTop();
-  let link_id = $(this).attr('href');
+  var windowScrollTop = $(window).scrollTop();
+  var link_id = $(this).attr('href');
   // debugPrint("navbar link clicked! " + link_id);
 
   // Get the y-position of the div we're clicking for
-  let div_pos = $(link_id).offset().top;
+  var div_pos = $(link_id).offset().top;
 
   scrollThisAmount(div_pos);
 
@@ -136,19 +139,20 @@ $('#gcs-navbar a').on('click', function()
  * 
  * 
  */
-$(window).scroll(function()
+// $(window).scroll(function()
+window.addEventListener('scroll', function()
 {
-  checkScroll($(this));
-});
+  checkScroll(this);
+}, false);
 
 function checkScroll(window)
 {
-  let windowScrollTop = window.scrollTop();
-  let window_bottom = windowHeight + windowScrollTop;
-  debugPrint(`window bottom = ${window_bottom}`);
+  var windowScrollTop = window.pageYOffset;
+  var window_bottom = windowHeight + windowScrollTop;
+  debugPrint('window bottom = ' + (window_bottom));
   // debugPrint('bottom window position = ' + window_bottom);
 
-  // let windowScrollDelta = windowScrollTop - last_windowScrollTop;
+  // var windowScrollDelta = windowScrollTop - last_windowScrollTop;
 
   // BG Parallax Scrolling Effect
   // $('#gcs-backgrounds').animate(
@@ -178,7 +182,7 @@ function checkScroll(window)
 
   if (!projects_visible)
   {
-    for (let i = 0; i <project_divs.length; i++)
+    for (var i = 0; i <project_divs.length; i++)
     {
       if (!project_divs[i].visible && window_bottom > project_divs[i].dims.pos + project_divs[i].dims.height)
       {
@@ -186,12 +190,12 @@ function checkScroll(window)
         showSpin($(project_divs[i]).children('.project-panel'));
       }
     }
-    let visible_arr = project_divs.filter(function()
+    var visible_arr = project_divs.filter(function()
     {
       // debugPrint('project_div.visible: ' + project_div.visible);
       return this.visible;
     });
-    debugPrint(`team_visible_arr.length=${visible_arr.length}, team_divs.length=${project_divs.length}`);
+    debugPrint('team_visible_arr.length=' + (visible_arr.length) + ', team_divs.length=' + (project_divs.length));
     projects_visible = project_divs.length > 0 && visible_arr.length == project_divs.length;
   }
   else
@@ -200,7 +204,7 @@ function checkScroll(window)
 
   if (!team_members_visible)
   {
-    for (let i = 0; i < team_divs.length; i++)
+    for (var i = 0; i < team_divs.length; i++)
     {
       // debugPrint(`team_divs[${i}].visible = ${team_divs[i].visible}`);
       if (!team_divs[i].visible && window_bottom > team_divs[i].dims.pos + team_divs[i].dims.height)
@@ -214,7 +218,7 @@ function checkScroll(window)
     {
       return this.visible;
     });
-    debugPrint(`team_visible_arr.length=${team_visible_arr.length}, team_divs.length=${team_divs.length}`);
+    debugPrint('team_visible_arr.length=' + (team_visible_arr.length) + ', team_divs.length=' + (team_divs.length));
     team_members_visible = team_divs.length > 0 && team_visible_arr.length == team_divs.length;
     // debugPrint("visible array: " + visible_arr);
   }
@@ -319,7 +323,7 @@ var determineBackground = function(scroll_pos)
     bg_arr_index = new_bg_arr_index;
     $('#gcs-backgrounds').css(
       {
-        transform: `translateY(-${100 * bg_arr_index}vh)`
+        transform: 'translateY(-' + (100 * bg_arr_index) + 'vh)'
       }
     );
   }


### PR DESCRIPTION
…s (IE doesn't seem to support ES6).
- Changed 'let' variables back to 'var' (another ES6 feature not yet supported by IE).
- Changed from jQuery methods/properties into their pure Javascript equivalent (to get support on IE and Safari 5).
- Centered the headlines in the About section.
